### PR TITLE
Ability to go back to the overworld from a world map without Funky

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ To be assembled using [Asar](https://github.com/RPGHacker/asar), see the Makefil
 - manage your kongs on the map (by BlueImp)
 	- `L` to toggle between having 1 or 2 kongs
 	- `R` to change which kong is in front
+- quickly return to the overworld from a world map by pressing `select`
 
 you're probably gonna need a completed save file for now, sorry

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ To be assembled using [Asar](https://github.com/RPGHacker/asar), see the Makefil
 - infinite lives
 - DK coins will always respawn
 - manage your kongs on the map (by BlueImp)
-	- `L` to toggle between having 1 or 2 kongs
-	- `R` to change which kong is in front
-- quickly return to the overworld from a world map by pressing `select`
+	- hold `R` and press `L` to toggle between having 1 or 2 kongs
+	- hold `R` and press `select` to change which kong is in front
+- hold `L` and press `R` to toggle the autojump state on and off
+- hold `L` and press `select` to quickly return to the overworld from a world map
 
 you're probably gonna need a completed save file for now, sorry

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -1,4 +1,4 @@
-@include
+include
 
 ; define rom locations based on rom revision
 if !rom_revision == 0

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -15,6 +15,8 @@ if !rom_revision == 0
 	end_bananas = $BEC89F
 	draw_digit = $BEC814
 	freerom_BE = $BEFB8A
+	play_high_priority_sound = $B58021
+	vgheroes_check = $B4877D
 elseif !rom_revision == 1
 	hijack_level = $808640
 	hijack_nmi = $80F3D8
@@ -29,6 +31,8 @@ elseif !rom_revision == 1
 	end_bananas = $BEC8AA
 	draw_digit = $BEC81F
 	freerom_BE = $BEFB67
+	play_high_priority_sound = $B58021
+	vgheroes_check = $B4878F
 endif
 
 ; constants
@@ -36,6 +40,8 @@ endif
 !dropped_frames_y = $0900
 !timer_x = $00CC
 !timer_y = $0900
+!sfx_notallowed = $5F
+!sfx_balloon = $2C
 
 ; wram
 !freeram = $1A00
@@ -61,6 +67,8 @@ endmacro
 !extra_kong_flag = $08C2
 !level_state = $0AF1
 
+!counter_60hz_pausable = $002A
+!counter_60hz_pausable_dp = $2A
 !counter_60hz = $2C
 
 !reg_joy1l = $4218

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -46,6 +46,8 @@ macro def_freeram(id, size)
 	!freeram_used #= !freeram_used+<size>
 endmacro
 
+!nmi_pointer = $0020
+!nmi_pointer_dp = $20
 !io_axlr = $050E
 !io_byetudlr = $050F
 !io_axlr_1f = $0510
@@ -53,12 +55,16 @@ endmacro
 !fade_type = $0513
 !main_kong = $0593
 !follower_kong = $0597
+!map_index = $06B1
 !current_map_kong = $08A4
 !pause_flags = $08C2
 !extra_kong_flag = $08C2
 !level_state = $0AF1
 
 !counter_60hz = $2C
+
+!reg_joy1l = $4218
+!reg_joy1h = $4219
 
 %def_freeram(previous_60hz, 2)
 

--- a/src/edits.asm
+++ b/src/edits.asm
@@ -1,4 +1,4 @@
-@include
+include
 
 ; u1.0 checksum
 org $00FFDC

--- a/src/edits.asm
+++ b/src/edits.asm
@@ -21,3 +21,7 @@ org bypass_hud_face
 ; always spawn dk coins as not collected
 org dk_coin_check
 		BRA $0E
+
+; don't load the video game heroes screen
+org vgheroes_check
+		BRA $11 : NOP

--- a/src/hijacks.asm
+++ b/src/hijacks.asm
@@ -1,4 +1,4 @@
-@include
+include
 
 org hijack_level
 		JSL every_igt_frame

--- a/src/hud.asm
+++ b/src/hud.asm
@@ -1,4 +1,4 @@
-@include
+include
 
 handle_displays:
 		SEP #$20

--- a/src/level.asm
+++ b/src/level.asm
@@ -1,4 +1,4 @@
-@include
+include
 
 every_igt_frame:
 		JSR handle_frame_counters

--- a/src/main.asm
+++ b/src/main.asm
@@ -1,3 +1,4 @@
+asar 1.91
 hirom
 
 ; 0 for 1.0
@@ -13,9 +14,9 @@ org freerom_BB
 incsrc "level.asm"
 incsrc "map.asm"
 
-warnpc $BBFFFF
+assert pc() <= $BBFFFF
 
 org freerom_BE
 incsrc "hud.asm"
 
-warnpc $BEFFFF
+assert pc() <= $BEFFFF

--- a/src/map.asm
+++ b/src/map.asm
@@ -14,12 +14,33 @@ every_map_frame:
 		LDA !counter_60hz
 		STA !previous_60hz
 
+		JSR check_goto_overworld
 		JSR check_kong_swap
 
 		SEP #$20
 		LDA $0512
 		RTL
 
+
+check_goto_overworld:
+		; using the hardware reg here since the game doesn't clear controller data when start+select-ing out of a stage
+		LDA !reg_joy1h : BIT #$0020 : BEQ .done ; select pressed?
+
+		; the nmi_pointer selects the address in bank $80 to run at the start of each frame
+		; $8087D9 jumps to $B5CDFD, which loads a world map screen based on the value in map_index
+		LDA #$87D9 : STA !nmi_pointer_dp
+		STZ !map_index ; 0 = overworld
+
+		; $06AF/B0 seems to store a movement value for when the kongs move between map nodes
+		; if you try to load the overworld while this is non-zero, you will softlock as they run offscreen
+		STZ $06AF
+
+		; $06AD seems to store a value that dictates where the kongs move after beating a level
+		; it gets set even when they don't move automatically, and is only cleared when a new node is reached
+		; zeroing it prevents another softlock when loading the overworld immediately after beating a level
+		STZ $06AD
+	.done:
+		RTS
 
 check_kong_swap:
 		; if L was pressed, toggle between 1 or 2 kongs

--- a/src/map.asm
+++ b/src/map.asm
@@ -1,4 +1,4 @@
-@include
+include
 
 every_map_frame:
 		STZ !dropped_frames


### PR DESCRIPTION
This PR lets the player press select at any time while on a world map to load the overworld.
I also updated asar since I'm on 1.91 and was getting spammed by deprecation warnings, but I can take that commit out if you want.
Also chucked in the ability to toggle autojump if you think that's worth adding, had to do some rebinding for it though - not enough buttons on the controller!